### PR TITLE
Remove all pre-commit references from documentation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -31,4 +31,3 @@ LICENSE
 
 # CI/CD
 .github/
-.pre-commit-config.yaml.example

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,12 +23,6 @@ In R: `renv::snapshot()` to update renv.lock after adding packages.
 ### R Version
 R version is pinned in `.Rversion` (currently 4.5.1). `.Rprofile` checks version on startup and warns if mismatched.
 
-### Pre-commit Hooks (Optional)
-```bash
-cp .pre-commit-config.yaml.example .pre-commit-config.yaml
-pre-commit install
-```
-
 ## Architecture
 
 **Data Flow**: `data/raw/` (immutable) → `scripts/R/` → `output/figures|tables/` → `paper/index.qmd` → `paper/index.pdf`
@@ -70,7 +64,6 @@ pre-commit install
 ## Important Notes
 
 - **R version**: Must match `.Rversion` for reproducibility
-- **Pre-commit**: Optional, copy from `.example` to enable
 - **PDF location**: `paper/index.pdf` (gitignored)
 - **Figures**: Auto-saved to `output/figures/` via knitr settings
 - **LaTeX**: Kept in `paper/` for debugging (`keep-tex: true`)


### PR DESCRIPTION
Pre-commit hooks have been removed from the repository. This commit removes all remaining references to pre-commit from documentation files.

Changes:
- CLAUDE.md: Removed "Pre-commit Hooks (Optional)" section
- CLAUDE.md: Removed pre-commit from Important Notes
- .dockerignore: Removed .pre-commit-config.yaml.example reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed pre-commit hooks setup guidance and associated instructions from the contribution guidelines.

* **Chores**
  * Updated Docker build context configuration to include pre-commit configuration files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->